### PR TITLE
smail send: .smail extension can now be included + added help text

### DIFF
--- a/src/help.rs
+++ b/src/help.rs
@@ -1,0 +1,36 @@
+use crate::io::output::BOLD;
+use crate::io::output::RESET;
+
+pub fn printhelp() {
+	println!("{}", [
+		"SMAIL -- command line tool for sending HTML e-mails",
+		"",
+		&[ "Usage: ", BOLD, "smail", RESET," [flags] <command> ..." ].join(""),
+		"",
+		"Possible flags:",
+		"\t--config=/path/to/config - specifies a custom config file path,",
+		"\t                           otherwise ~/.smailconf will be used",
+		"",
+		"Possible commands:",
+		&[ "\tsmail ", BOLD, "init", RESET, " [--overwrite] - create a new configuration file" ].join(""),
+		"\t\t--overwrite = forces the creation of a configuration file,",
+		"\t\t              even if it already exists",
+		"",
+		&[ "\tsmail ", BOLD, "create", RESET, " <filename> <?filename> ... - creates empty .smail template(s)" ].join(""),
+		"",
+		&[ "\tsmail ", BOLD, "send", RESET, " <filename> <?filename> ... - sends filled in .smail file(s)" ].join(""),
+		"",
+		&[ "\tsmail ", BOLD, "send", RESET, " - sends a filled SMAIL file from stdin" ].join(""),
+		"",
+		&[ "\tsmail --stdin=\"...\" ", BOLD, "send", RESET ].join(""),
+		"\t\t- sends a filled SMAIL file passed as raw text in the command line",
+		"\t\t  argument, lines separated with \"\\n\"",
+		"",
+		&[ "\tsmail --stdin=\"...\" --argument-override-newline=\"delim\" ", BOLD, "send", RESET ].join(""),
+		"\t\t- sends a filled SMAIL file passed as raw text in the command line",
+		"\t\t  argument, lines separated with the custom delimiter",
+		"",
+		"For more information about SMAIL, please visit the project's repository:",
+		"\thttps://github.com/omekina/smail"
+	].join("\n"));
+}

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -1,8 +1,8 @@
-const RED: &'static str = "\x1b[31m";
-const GREEN: &'static str = "\x1b[32m";
-const YELLOW: &'static str = "\x1b[33m";
-const RESET: &'static str = "\x1b[0m";
-
+pub const RED: &'static str = "\x1b[31m";
+pub const GREEN: &'static str = "\x1b[32m";
+pub const YELLOW: &'static str = "\x1b[33m";
+pub const RESET: &'static str = "\x1b[0m";
+pub const BOLD: &'static str = "\x1b[1m";
 
 pub fn warning(message: &str) {
     println!("{}{}{}", YELLOW, message, RESET);

--- a/src/mail_file/loader.rs
+++ b/src/mail_file/loader.rs
@@ -15,16 +15,22 @@ pub struct MailField {
 Load e-mail file into fields.
 */
 pub fn load_mail_file(filepath: &String) -> Option<Vec<MailField>> {
-    let contents: String = match read_to_string(&(filepath.clone() + ".smail")) {
-        Ok(value) => value,
-        Err(_) => {
-            output::error("Could not read from SMAIL file.");
-            println!("Maybe you forgot to 'smail create'?");
-            return None;
-        },
-    };
+    let possiblepaths = vec![
+        filepath.clone(),
+        (filepath.clone() + ".smail")
+    ];
 
-    return parse_mail_file(&contents);
+    for path in possiblepaths {
+        let contents = read_to_string(path);
+
+        if contents.is_ok() {
+            return parse_mail_file(&contents.ok()?);
+        }
+    }
+
+    output::error("Could not read from SMAIL file.");
+    println!("Maybe you forgot to 'smail create'?");
+    return None;
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod io;
 mod connection;
 mod sender;
 mod flags;
-
+mod help;
 
 use std::env::args;
 use config::loader::{ConfigItem, load_config};
@@ -60,6 +60,7 @@ fn runtime() -> i32 {
     /* Get target action and trim the arguments. */
     if console_arguments.len() == 0 {
         io::output::warning("No command specified.");
+        println!("To see all possible commands, run \"smail help\".");
         return 1;
     }
     let action = console_arguments[0].clone();
@@ -100,8 +101,15 @@ fn runtime() -> i32 {
         };
     }
 
+    /* If help command was issued -> display help. */
+
+    if action == "help" {
+        help::printhelp();
+        return 0;
+    }
+
     /* If no command was matched -> exit. */
-    io::output::warning("Command not known:");
-    println!("{}", action);
+    io::output::warning(&format!("Command not known: {}", action));
+    println!("To see all possible commands, run \"smail help\".");
     return 1;
 }


### PR DESCRIPTION
```
$ smail
No command specified.
To see all possible commands, run "smail help".

$ smail asdhfjkl
Command not known: asdhfjkl
To see all possible commands, run "smail help".
```